### PR TITLE
fix(Sidenav): :bug: Close opened sidenav when users click on content.

### DIFF
--- a/src/app/components/content/content.component.html
+++ b/src/app/components/content/content.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container class="container">
+<mat-sidenav-container class="container" (backdropClick)="closeSidenav()">
     <mat-sidenav
         class="sidenav"
         [mode]="modeSideNav"

--- a/src/app/components/content/content.component.scss
+++ b/src/app/components/content/content.component.scss
@@ -31,6 +31,10 @@
     }
 }
 
+mat-sidenav-content {
+    height: calc(100vh - 50px); // 50px = banner's height
+}
+
 @include media-queries('medium') {
     .container {
         padding-top: 20vh;
@@ -43,6 +47,10 @@
                 font-size: $font-size-medium;
             }
         }
+    }
+
+    mat-sidenav-content {
+        height: 100%;
     }
 }
 

--- a/src/app/components/content/content.component.ts
+++ b/src/app/components/content/content.component.ts
@@ -9,6 +9,7 @@ import { AppState } from '../../app.component';
 import { changeCategory } from '../../core/category/category.actions';
 import { Category } from '../../core/category/category.enum';
 import { selectCurrentCategory } from '../../core/category/category.selectors';
+import { toggleSidenav } from '../../core/sidenav/sidenav.actions';
 import { initialSidenavState } from '../../core/sidenav/sidenav.reducers';
 import { selectIsSidenavOpened } from '../../core/sidenav/sidenav.selectors';
 import { CardComponent } from '../../shared/card/card.component';
@@ -17,7 +18,6 @@ import { professionalExperiences } from './professional-experiences/professional
 import { studies } from './studies/studies';
 import { SummaryComponent } from './summary/summary.component';
 import { trainingCourses } from './training-courses/training-courses';
-import { toggleSidenav } from '../../core/sidenav/sidenav.actions';
 
 @Component({
     selector: 'app-content',
@@ -84,5 +84,12 @@ export class ContentComponent implements OnDestroy {
             shouldToggleSidenav: this.isPortaitOrientedMobile
         };
         this.store.dispatch(changeCategory(props));
+    }
+
+    protected closeSidenav() {
+        const props = {
+            isSidenavOpened: !this.isSidenavOpened
+        };
+        this.store.dispatch(toggleSidenav(props));
     }
 }


### PR DESCRIPTION
- Allows to close sidenav even if the click is not precisely on content by making content's size takes all the place. 
- And close sidenav when matSidenav container's backdrop is clicked