### PR TITLE
ci(github-actions): :construction_worker: Update github actions.

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -11,10 +11,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository files
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
                   cache: npm

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,7 +30,8 @@
         "studies",
         "hobbies",
         "release",
-        "deps"
+        "deps",
+        "github-actions"
     ],
     "typescript.tsdk": "node_modules\\typescript\\lib"
 }


### PR DESCRIPTION
Update checkout and setup-node actions in order to not use node 16 as it is not supported anymore but node 20 instead.